### PR TITLE
fix: allow PR workflow comments

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,11 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 env:
   PYTHON_VERSION: "3.9"
 


### PR DESCRIPTION
## Summary
- grant the Pull Request Checks workflow permission to write PR comments
- fixes the red PR workflow jobs that failed with `Resource not accessible by integration`

## Validation
- parsed `.github/workflows/pr.yml` with Python/YAML