### PR TITLE
fix: stabilize Rocky nightly package setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,7 +191,7 @@ jobs:
               PYTHON_BIN=python3
             elif command -v yum >/dev/null; then
               yum update -y
-              yum install -y curl-minimal make
+              yum install -y make
               if yum install -y python39 python39-pip; then
                 PYTHON_BIN=python3.9
               else

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -191,7 +191,7 @@ jobs:
               PYTHON_BIN=python3
             elif command -v yum >/dev/null; then
               yum update -y
-              yum install -y curl make
+              yum install -y curl-minimal make
               if yum install -y python39 python39-pip; then
                 PYTHON_BIN=python3.9
               else


### PR DESCRIPTION
## Summary
- Fix Rocky Linux compatibility setup in the nightly workflow.
- Stop installing the full `curl` package in yum-based images and install only `make`, which is the missing tool needed by the workflow.

## Root cause
The current `rockylinux:9` image contains `curl-minimal`. The nightly workflow tried to install `curl`, which conflicts with the installed minimal package and stopped before Ansible tests started. Rocky 8 has the inverse package-shape issue after update, so the portable fix is to avoid installing curl in the yum branch entirely.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly.yml"); puts "nightly.yml YAML OK"'`
- `actionlint .github/workflows/nightly.yml`
- Manual Nightly Tests workflow run on the PR branch; first run confirmed Rocky 9 passes and exposed the Rocky 8 package-name issue, now addressed.

